### PR TITLE
Dark theme added with toggle

### DIFF
--- a/app/src/main/java/com/example/movieflix/presentation/MainActivity.kt
+++ b/app/src/main/java/com/example/movieflix/presentation/MainActivity.kt
@@ -1,11 +1,14 @@
 package com.example.movieflix.presentation
 
+import android.content.Context
+import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.PopupMenu
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.navigation.fragment.NavHostFragment
 import com.example.movieflix.R
 import com.example.movieflix.databinding.ActivityMainBinding
@@ -19,14 +22,57 @@ class MainActivity : AppCompatActivity() {
                 as NavHostFragment).navController
     }
     private lateinit var binding: ActivityMainBinding
-
+    private lateinit var sharedPreferences: SharedPreferences
+    private val PREFS_NAME = "theme_prefs"
+    private val KEY_THEME = "theme_mode"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        // Initialize SharedPreferences for theme persistence
+        sharedPreferences = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
+        // Load saved theme preference
+        val savedTheme = sharedPreferences.getInt(KEY_THEME, AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+        AppCompatDelegate.setDefaultNightMode(savedTheme)
+
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.main_menu, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.action_toggle_theme -> {
+                toggleTheme()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    private fun toggleTheme() {
+        // Get current night mode
+        val currentMode = AppCompatDelegate.getDefaultNightMode()
+        val newMode = if (currentMode == AppCompatDelegate.MODE_NIGHT_YES) {
+            AppCompatDelegate.MODE_NIGHT_NO
+        } else {
+            AppCompatDelegate.MODE_NIGHT_YES
+        }
+
+        // Apply new theme
+        AppCompatDelegate.setDefaultNightMode(newMode)
+
+        // Save preference
+        sharedPreferences.edit().putInt(KEY_THEME, newMode).apply()
+
+        // Show user feedback
+        val themeText = if (newMode == AppCompatDelegate.MODE_NIGHT_YES) "Dark Mode" else "Light Mode"
+        Toast.makeText(this, "Switched to $themeText", Toast.LENGTH_SHORT).show()
     }
 
     @Deprecated("Deprecated in Java")

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_toggle_theme"
+        android:title="Toggle Theme"
+        android:icon="@android:drawable/ic_menu_preferences"
+        app:showAsAction="never" />
+</menu>


### PR DESCRIPTION
This feature allows users to manually switch between light and dark themes within the app, independent of their system settings. Users can access this via a new menu option in the main activity.