### PR TITLE
feat: Implement play/pause toggle for trailer button

### DIFF
--- a/app/src/main/res/drawable/ic_pause.xml
+++ b/app/src/main/res/drawable/ic_pause.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/black">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6,19h4L10,5L6,5v14zM14,5v14h4L18,5h-4z"/>
+</vector>


### PR DESCRIPTION
eat: Add play/pause toggle for YouTube trailer

- Clicking play button now pauses video instead of restarting
- Button text and icon update dynamically (Play/Pause)
- Video resumes from paused position