### PR TITLE
fix #50 Added a check before navigating to DetailsFragment

### DIFF
--- a/app/src/main/java/com/example/movieflix/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/movieflix/presentation/home/HomeFragment.kt
@@ -92,12 +92,31 @@ class HomeFragment : BaseFragment() {
         }
     }
 
+    object ClickHandler{
+        private var lastClick = 0L;
+
+        fun isClickAllowed(): Boolean {
+            val allowUser = System.currentTimeMillis() - lastClick > 1000L
+            if(allowUser){
+                lastClick = System.currentTimeMillis()
+            }
+            return allowUser;
+
+        }
+    }
+
     private fun openDetailFragment(it: MovieResult) {
+
+        if(!ClickHandler.isClickAllowed()){
+            return
+        }
         val bundle = Bundle()
         bundle.putString(Constants.MEDIA_SEND_REQUEST_KEY, Gson().toJson(it))
 
         findNavController().navigate(R.id.action_homeFragment_to_movieDetailsFragment, bundle)
     }
+
+
 
     private fun observer() {
         homeInfoViewModel.homeFeedList.observe(viewLifecycleOwner) {


### PR DESCRIPTION
fixes #50
Issue:
When users tapped movie cards (or the banner) quickly, the app could try to navigate to MovieDetailsFragment more than once almost simultaneously. While the first navigation was in progress the second call would run when the NavController’s current destination had already changed, which caused this crash:
`IllegalArgumentException: Navigation action/destination ... action_homeFragment_to_movieDetailsFragment cannot be found from the current destination Destination(...:movieDetailsFragment)
`
What I changed
In HomeFragment.kt I added a simple click guard and used it before navigating:
- Added a ClickHandler object that remembers the last tap timestamp.
- isClickAllowed() returns true only if enough time (1 second) has passed since the previous allowed click; otherwise it returns false.
- openDetailFragment() now checks ClickHandler.isClickAllowed() and returns early if not allowed, so only one navigation can be triggered in a short interval.

https://github.com/user-attachments/assets/df283336-e96c-47e2-ac8f-89bc58d6a197


